### PR TITLE
Update Quickstart to clarify SSO Authorization

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -117,7 +117,7 @@
    
    ![GH2](./images/GH-setup2.png)
    
-   2.11. If your organization uses single sign on for Github, then click on "Authorize" the token to have access to the github organization. 
+   2.11. If your organization uses single sign on for Github, then click on "Authorize" the token to have access to the github organization. The screenshot below shows an example of authorization for the token to interact with your repository. Your organization maybe different. 
    
    ![GH3](./images/GH-setup3.png)
    


### PR DESCRIPTION
The documentation looks as if there is a requirement to have Azure organization to be able to use this repository. Updated the documentation to clarify that it is an example screenshot.

Resolves #23 


