### PR TITLE
Added instructions for creating compute instances with no/SystemAssigned/UserAssigned Managed Identities.

### DIFF
--- a/documentation/deployguides/deployguide_ado.md
+++ b/documentation/deployguides/deployguide_ado.md
@@ -472,7 +472,8 @@ In this section you will execute an Azure DevOps pipeline that will create and r
 * If the new model performs better, register the model as an MLflow model in the workspace for later deployment
 
 <details>
-<summary>Create Compute Instances with SystemAssigned/UserAssigned/No Managed Identity</summary>
+<summary>**Create Compute Instances with SystemAssigned/UserAssigned/No Managed Identity**</summary>
+
 
 In order to create a compute instance with or without managed identity, you can leverage the `/mlops-templates/templates/python-sdk-v2/create-compute-instance.yml` located within the **mlops-templates** repository. If you want to create a compute instance without a managed identity reference, you can add the following snippet with your own parameters to the `/mlops/devops-pipelines/deploy-model-training-pipeline.yml` pipeline definition:
 
@@ -509,7 +510,7 @@ Lastly, to leveraged a user-assigned managed identity for your compute, the foll
         identity_type: UserAssigned
         user_assigned_identity: e12c9326-0618-4036-a0a7-ad3bb396dc97
    ```
-   
+
 </details>
 
 To deploy the model training pipeline, open the **Pipelines** section again and select **New pipeline** in the upper right of the page

--- a/documentation/deployguides/deployguide_ado.md
+++ b/documentation/deployguides/deployguide_ado.md
@@ -463,13 +463,54 @@ The solution accelerator includes code and data for a sample end-to-end machine 
 In this section you will execute an Azure DevOps pipeline that will create and run an Azure Machine Learning pipeline. Together, they perform the following steps:
 
 * Connect to the Azure Machine Learning workspace created by the infrastructure deployment  
-* Create a compute cluster for training in the workspace   
+* Create a compute cluster for training in the workspace (refer to section below to create compute instances with or without managed identity)
 * Register the training dataset in the workspace   
 * Prepare data for training  
 * Registers a custom python environment with the packages required for this model  
 * Train a linear regression model to predict taxi fares  
 * Evaluate the model on the test dataset against the performance of any previously-registered models  
 * If the new model performs better, register the model as an MLflow model in the workspace for later deployment
+
+<details>
+<summary>Create Compute Instances with SystemAssigned/UserAssigned/No Managed Identity</summary>
+
+In order to create a compute instance with or without managed identity, you can leverage the `/mlops-templates/templates/python-sdk-v2/create-compute-instance.yml` located within the **mlops-templates** repository. If you want to create a compute instance without a managed identity reference, you can add the following snippet with your own parameters to the `/mlops/devops-pipelines/deploy-model-training-pipeline.yml` pipeline definition:
+
+   ``` yaml
+    - template: templates/python-sdk-v2/create-compute-instance.yml@mlops-templates
+      parameters:
+        instance_name: compute-instance-a
+        size: Standard_DS3_v2
+        location: canadacentral
+        description: compute instance a
+   ```
+
+In order to create a system-assigned managed identity and assign it your compute instance during creation, the above snippet can be adjusted as follows:
+
+   ``` yaml
+    - template: templates/python-sdk-v2/create-compute-instance.yml@mlops-templates
+      parameters:
+        instance_name: compute-instance-a
+        size: Standard_DS3_v2
+        location: canadacentral
+        description: compute instance a
+        identity_type: SystemAssigned
+   ```
+
+Lastly, to leveraged a user-assigned managed identity for your compute, the following snippet can be used and adjusted as needed:
+
+   ``` yaml
+    - template: templates/python-sdk-v2/create-compute-instance.yml@mlops-templates
+      parameters:
+        instance_name: compute-instance-a
+        size: Standard_DS3_v2
+        location: canadacentral
+        description: compute instance a
+        identity_type: UserAssigned
+        user_assigned_identity: e12c9326-0618-4036-a0a7-ad3bb396dc97
+   ```
+   
+</details>
 
 To deploy the model training pipeline, open the **Pipelines** section again and select **New pipeline** in the upper right of the page
    

--- a/documentation/deployguides/deployguide_ado.md
+++ b/documentation/deployguides/deployguide_ado.md
@@ -472,10 +472,12 @@ In this section you will execute an Azure DevOps pipeline that will create and r
 * If the new model performs better, register the model as an MLflow model in the workspace for later deployment
 
 <details>
-<summary>**Create Compute Instances with SystemAssigned/UserAssigned/No Managed Identity**</summary>
+<summary><strong>Create Compute Instances with SystemAssigned/UserAssigned/No Managed Identity</strong></summary>
+<br>
 
+In order to create a compute instance with or without managed identity, you can leverage the `/mlops-templates/templates/python-sdk-v2/create-compute-instance.yml` located within the **mlops-templates** repository. 
 
-In order to create a compute instance with or without managed identity, you can leverage the `/mlops-templates/templates/python-sdk-v2/create-compute-instance.yml` located within the **mlops-templates** repository. If you want to create a compute instance without a managed identity reference, you can add the following snippet with your own parameters to the `/mlops/devops-pipelines/deploy-model-training-pipeline.yml` pipeline definition:
+If you want to create a **compute instance without a managed identity** reference, you can add the following snippet with your own parameters to the `/mlops/devops-pipelines/deploy-model-training-pipeline.yml` pipeline definition:
 
    ``` yaml
     - template: templates/python-sdk-v2/create-compute-instance.yml@mlops-templates
@@ -486,7 +488,7 @@ In order to create a compute instance with or without managed identity, you can 
         description: compute instance a
    ```
 
-In order to create a system-assigned managed identity and assign it your compute instance during creation, the above snippet can be adjusted as follows:
+In order to **create a system-assigned managed identity** and assign it your compute instance during creation, the above snippet can be adjusted as follows:
 
    ``` yaml
     - template: templates/python-sdk-v2/create-compute-instance.yml@mlops-templates
@@ -498,7 +500,7 @@ In order to create a system-assigned managed identity and assign it your compute
         identity_type: SystemAssigned
    ```
 
-Lastly, to leveraged a user-assigned managed identity for your compute, the following snippet can be used and adjusted as needed:
+Lastly, to leverage a **user-assigned managed identity** for your compute, the following snippet can be used and adjusted as needed:
 
    ``` yaml
     - template: templates/python-sdk-v2/create-compute-instance.yml@mlops-templates


### PR DESCRIPTION
Added instructions to accompany PR https://github.com/Azure/mlops-templates/pull/72 within the mlops-templates repository. Specifically:

- Added instruction for creating base compute instance using Python SDK V2 for model training pipeline
- Added instruction to assign a system-assigned managed identity to compute instance during creation
- Added instruction to assign a pre-created user-assigned managed identity to compute instance during creation

![image](https://github.com/Azure/mlops-v2/assets/160765761/c625864f-7f24-4afc-80a7-f55096571a9a)
