### PR TITLE
fix(ado): initialise pipeline — pool/queue + harden initialise_repo.sh (closes #144, #145, #146)

### DIFF
--- a/.azuredevops/initialise-project.yml
+++ b/.azuredevops/initialise-project.yml
@@ -59,6 +59,8 @@ stages:
     jobs:
       - job: InitialiseProjectJob
         displayName: Checkout repos, initialise your new one and create pipelines
+        pool:
+          vmImage: ubuntu-latest
         steps:
           - checkout: self
             persistCredentials: false

--- a/.azuredevops/scripts/create_ado_pipelines.sh
+++ b/.azuredevops/scripts/create_ado_pipelines.sh
@@ -3,6 +3,23 @@ project_name=$2
 path_to_infrastructure_pipelines=infrastructure/pipelines
 path_to_mlops_pipelines=mlops/devops-pipelines
 
+# Resolve the agent queue ID for the hosted "Azure Pipelines" pool. Without
+# --queue-id, `az pipelines create` may fail with "Could not queue the build
+# because there were validation errors or warnings" on newly-provisioned ADO
+# projects where the default queue association has not yet been established.
+# Override by exporting AGENT_POOL_NAME before running this script if you use
+# a self-hosted pool.
+agent_pool_name="${AGENT_POOL_NAME:-Azure Pipelines}"
+queue_id=$(az pipelines queue list \
+    --project "$project_name" \
+    --query "[?name=='$agent_pool_name'].id | [0]" \
+    -o tsv)
+
+if [ -z "$queue_id" ]; then
+    echo "WARNING: Could not resolve queue ID for agent pool '$agent_pool_name'." >&2
+    echo "Pipelines will be created without --queue-id; first run may need to be triggered manually." >&2
+fi
+
 cd $repo_name
 
 az pipelines folder create \
@@ -31,7 +48,8 @@ do
         --project $project_name \
         --repository-type tfsgit \
         --skip-first-run true \
-        --folder-path $repo_name/mlops
+        --folder-path $repo_name/mlops \
+        ${queue_id:+--queue-id $queue_id}
 done
 
 infra_pipeline_files=$(ls $path_to_infrastructure_pipelines)
@@ -48,5 +66,6 @@ do
         --project $project_name \
         --repository-type tfsgit \
         --skip-first-run true \
-        --folder-path $repo_name/infrastructure
+        --folder-path $repo_name/infrastructure \
+        ${queue_id:+--queue-id $queue_id}
 done

--- a/.azuredevops/scripts/initialise_repo.sh
+++ b/.azuredevops/scripts/initialise_repo.sh
@@ -1,49 +1,101 @@
+# Fail fast on errors, undefined vars, or any failing command in a pipeline.
+# Without this the script silently continues past missing files and produces
+# an empty target repository while the pipeline reports success.
+set -euo pipefail
+
 repo_name=$1
 project_type=$2
 mlops_version=$3
 template_repo=$4
-#infrastructure_version=bicep #options: terraform / bicep 
-infrastructure_version=$5 #options: terraform / bicep 
+#infrastructure_version=bicep #options: terraform / bicep
+infrastructure_version=$5 #options: terraform / bicep
+
+echo "=== initialise_repo.sh ==="
+echo "repo_name=${repo_name}"
+echo "project_type=${project_type}"
+echo "mlops_version=${mlops_version}"
+echo "template_repo=${template_repo}"
+echo "infrastructure_version=${infrastructure_version}"
+echo "cwd=$(pwd)"
+ls -la
+
+# Validate required source directories before we start mutating anything.
+# The Azure DevOps multi-repo checkout lays out repos as siblings of the
+# checkout root; if either repo is missing here, fail with a clear message.
+if [ ! -d "${template_repo}" ]; then
+  echo "ERROR: template repo directory '${template_repo}' not found in $(pwd)." >&2
+  echo "Hint: confirm 'checkout: <template_repo>' is declared in the pipeline and that" >&2
+  echo "      the repository name matches the value passed to this script." >&2
+  exit 1
+fi
+if [ ! -d "${repo_name}" ]; then
+  echo "ERROR: target repo directory '${repo_name}' not found in $(pwd)." >&2
+  echo "Hint: the target repo must be created and checked out before this step runs." >&2
+  exit 1
+fi
+if [ ! -d "${template_repo}/infrastructure/${infrastructure_version}" ]; then
+  echo "ERROR: '${template_repo}/infrastructure/${infrastructure_version}' not found." >&2
+  exit 1
+fi
+if [ ! -d "${template_repo}/${project_type}/${mlops_version}" ]; then
+  echo "ERROR: '${template_repo}/${project_type}/${mlops_version}' not found." >&2
+  exit 1
+fi
 
 git config --global user.email "hosted.agent@dev.azure.com"
 git config --global user.name "Azure Pipeline"
 
-mkdir files_to_keep
-mkdir files_to_delete
+mkdir -p files_to_keep files_to_delete
 
-cd $template_repo
-cp --parents -r infrastructure/$infrastructure_version ../files_to_keep
-cp --parents -r $project_type/$mlops_version ../files_to_keep
-cp config-infra-dev.yml ../files_to_keep
-cp config-infra-prod.yml ../files_to_keep
-cd ..
-mv $template_repo/* files_to_delete
+# Portable replacement for `cp --parents -r` (GNU coreutils only; not
+# available in macOS BSD cp or some Windows Git Bash builds). Preserves the
+# leading path component the rest of the script expects.
+mkdir -p "files_to_keep/infrastructure"
+cp -r "${template_repo}/infrastructure/${infrastructure_version}" "files_to_keep/infrastructure/"
+mkdir -p "files_to_keep/${project_type}"
+cp -r "${template_repo}/${project_type}/${mlops_version}" "files_to_keep/${project_type}/"
+cp "${template_repo}/config-infra-dev.yml" files_to_keep/
+cp "${template_repo}/config-infra-prod.yml" files_to_keep/
 
-cd $repo_name
+# Best-effort cleanup of the template checkout; not fatal if already empty.
+mv "${template_repo}"/* files_to_delete/ 2>/dev/null || true
+
+cd "${repo_name}"
 git checkout -b main
 cd ..
-rm $repo_name/*
-mv files_to_keep/* $repo_name
-cd $repo_name
 
-# Move files to appropiate level
-mv $project_type/$mlops_version/data-science data-science
-mv $project_type/$mlops_version/mlops mlops
-mv $project_type/$mlops_version/data data
+# Clear the target repo working tree while preserving .git so we can commit.
+find "${repo_name}" -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+mv files_to_keep/* "${repo_name}/"
+cd "${repo_name}"
 
-if [[ "$mlops_version" == "python-sdk" ]]
-then
+# Move files to appropriate level
+mv "${project_type}/${mlops_version}/data-science" data-science
+mv "${project_type}/${mlops_version}/mlops" mlops
+mv "${project_type}/${mlops_version}/data" data
+
+if [[ "${mlops_version}" == "python-sdk" ]]; then
   echo "python-sdk"
-  mv $project_type/$mlops_version/config-aml.yml config-aml.yml
+  mv "${project_type}/${mlops_version}/config-aml.yml" config-aml.yml
 fi
 
-rm -rf $project_type
+rm -rf "${project_type}"
 rm -rf mlops/github-actions
 
-mv infrastructure/$infrastructure_version $infrastructure_version
+mv "infrastructure/${infrastructure_version}" "${infrastructure_version}"
 rm -rf infrastructure
-mv $infrastructure_version infrastructure
+mv "${infrastructure_version}" infrastructure
 
-git add . && git commit -m 'initial commit'
+git add .
+
+# Refuse to push an empty repo. If staging is empty here, the copy steps
+# silently dropped everything and we'd be creating a false-positive success.
+if git diff --cached --quiet; then
+  echo "ERROR: no files staged for initial commit; target repository would be empty." >&2
+  echo "Hint: re-run with diagnostics above and check the cp/mv steps." >&2
+  exit 1
+fi
+
+git commit -m 'initial commit'
 git remote -v
 git push --set-upstream origin main

--- a/documentation/deployguides/deployguide_ado.md
+++ b/documentation/deployguides/deployguide_ado.md
@@ -644,6 +644,44 @@ These directories contain the yaml definitions and Azure ML pipelines for deploy
 
 This directory contains the Azure DevOps pipeline definitions for deployment of Azure ML model training and endpoint pipelines. In general, these should need minimal changes except for updating references to data and training pipelines.
 
+## Troubleshooting
+
+The following issues are commonly encountered on a fresh Azure DevOps organization.
+
+### "No hosted parallelism has been purchased or granted"
+
+By default, new Azure DevOps organizations have **zero** parallel jobs on Microsoft-hosted agents. The infrastructure pipeline will queue indefinitely until a free grant is approved.
+
+**Resolution:** Submit the free-tier parallelism request form: <https://aka.ms/azpipelines-parallelism-request>. Approval is typically granted within 2–3 business days. If you need to deploy immediately, configure a [self-hosted agent](https://learn.microsoft.com/azure/devops/pipelines/agents/agents).
+
+### "TF402455: Pushes to this branch are not permitted" or pipelines never appear
+
+The user account creating the pipelines (typically the project administrator running `initialise-project`) must have **Create build pipeline** permission on the project.
+
+**Resolution:** In Azure DevOps, navigate to **Project Settings → Permissions → Contributors** (or your group), and ensure **Create build pipeline** is set to *Allow*.
+
+### "A pipeline with name `deploy-...` already exists" on retry
+
+If the `initialise-project` pipeline fails partway through and you re-run it, the second run will fail because pipelines and folders from the first attempt still exist.
+
+**Resolution:** Before retrying, delete:
+
+1. The pipelines folder in **Pipelines → Pipelines** named after your repo.
+2. The repository created in **Repos** for the project.
+3. The corresponding `infrastructure/` folder if the infra pipeline partially executed and created resources in Azure — clean these up via the Azure portal or `az group delete`.
+
+### "No image label found to route agent pool Azure Pipelines. Pool: Azure Pipelines, Image: ubuntu-20.04"
+
+`ubuntu-20.04` was retired from the Microsoft-hosted agent pool. This affects older versions of `mlops-project-template` cloned before May 2026.
+
+**Resolution:** Update to the latest `mlops-project-template` (uses `ubuntu-latest`), or in your project repo replace `vmImage: ubuntu-20.04` with `vmImage: ubuntu-latest` in all `mlops/devops-pipelines/*.yml` and `infrastructure/.../*.yml` files.
+
+### `az pipelines create` fails with "Could not queue the build" during `initialise-project`
+
+The default agent queue association may not be established on a brand-new project.
+
+**Resolution:** The `create_ado_pipelines.sh` script now resolves the queue ID dynamically. If you use a self-hosted pool, set `AGENT_POOL_NAME` in the `initialise-project` pipeline variables before running.
+
 ## Next Steps in MLOps
 
 This guide illustrated using Azure DevOps pipelines and Azure Machine Learning pipelines to adopt training automation, deployment, and repeatability for your data science workflow for a single Azure ML environment. Follow on MLOps practices may include the following:


### PR DESCRIPTION
# PR Summary into Azure/mlops-v2

## Checklist

I have:

- [x] read and followed the contributing guidelines
- [x] PR has a meaningful title
- [x] Summarized the changes
- [x] PR is ready to merge and NOT **WORK IN PROGRESS**

## Changes

Three related fixes for issues users hit when running `initialise-project` on a freshly-provisioned Azure DevOps organization.

### 1. `initialise-project.yml` — missing agent pool

`InitialiseProjectJob` had no `pool:` block. ADO falls back to the org's default pool, which on new orgs may be unset, causing the job to fail to schedule. Added explicit:

```yaml
pool:
  vmImage: ubuntu-latest
```

### 2. `create_ado_pipelines.sh` — missing `--queue-id`

`az pipelines create` was called without `--queue-id`. On newly-provisioned projects this can fail with `"Could not queue the build because there were validation errors or warnings"` because the default queue-to-pool association is not yet established.

Fix: resolve the queue ID dynamically by pool name before the loops:

```bash
agent_pool_name="${AGENT_POOL_NAME:-Azure Pipelines}"
queue_id=$(az pipelines queue list \
    --project "$project_name" \
    --query "[?name=='$agent_pool_name'].id | [0]" \
    -o tsv)
```

Both `az pipelines create` calls now pass `${queue_id:+--queue-id $queue_id}` (the parameter is omitted gracefully if the lookup fails, preserving backward compatibility). Self-hosted pool users can override via the `AGENT_POOL_NAME` environment variable.

### 3. `deployguide_ado.md` — Troubleshooting section

Added a new **Troubleshooting** section before **Next Steps in MLOps**, covering the five most common failure modes reported by users:

1. **No hosted parallelism granted** — link to <https://aka.ms/azpipelines-parallelism-request>.
2. **Missing "Create build pipeline" permission** — Project Settings → Permissions.
3. **Stale folders/repo on retry** — clean-up checklist before re-running `initialise-project`.
4. **Retired `ubuntu-20.04` image** — pointer to fix in `mlops-project-template`.
5. **Queue association failure on new projects** — covered by the script change above.

## Testing

- `bash -n .azuredevops/scripts/create_ado_pipelines.sh` — syntax OK.
- `${queue_id:+--queue-id $queue_id}` expansion verified to expand only when set.
- Markdown rendering verified.

## Merge note

Requesting **squash and merge**.

Reported by Vicky Arpatzoglou via accelerator feedback (initialise-project failures, parallelism, build-pipeline permissions, stale folders, ubuntu-20.04 image).

fixes #


## Update — also fixes the init-script silent-failure bugs

Adds a second commit hardening `.azuredevops/scripts/initialise_repo.sh`. Root-caused @rod2k24's three bug reports to that script (no strict mode + GNU-only `cp --parents`).

- Add `set -euo pipefail` so the first failing `cp`/`mv`/`cd` aborts the step instead of producing a false-positive green pipeline.
- Replace `cp --parents -r` with portable `mkdir -p` + `cp -r` (works on GNU coreutils, macOS BSD `cp`, and Windows Git Bash).
- Validate `$template_repo`, `$repo_name`, and source subdirectories exist before mutating anything; print actionable error messages pointing at multi-repo checkout layout.
- Replace `rm $repo_name/*` with `find ... ! -name '.git' -exec rm -rf {} +` to be explicit about preserving `.git`.
- Guard against an empty staging area: fail loudly rather than committing nothing and pushing an empty initial commit.
- Echo invocation parameters and `cwd` up front for debuggability.

Fixes #144
Fixes #145
Fixes #146
